### PR TITLE
Replace "if" by "when"

### DIFF
--- a/src/todo/core.clj
+++ b/src/todo/core.clj
@@ -32,7 +32,7 @@
 (defn -main
   "I don't do a whole lot ... yet."
   [& args]
-  (if (nil? file-location)
+  (when (nil? file-location)
     (throw (AssertionError. "empty $TODO_LOCATION")))
   (case (first args)
     "a" (do


### PR DESCRIPTION
With Clojure, if `if` statement doesn't contains "else" branch so is recommended to use `when`.